### PR TITLE
Fix bug: can't translate tag to Chinese.

### DIFF
--- a/EhPanda/Network/Request.swift
+++ b/EhPanda/Network/Request.swift
@@ -104,7 +104,7 @@ struct TagTranslatorRequest {
                     .tryMap { data, _ in
                         guard let dict = try? JSONSerialization
                                 .jsonObject(with: data) as? [String: Any],
-                              isChinese ? dict["version"] as? Int == 5 : true
+                              isChinese ? dict["version"] as? Int == 6 : true
                         else { throw AppError.parseFailed }
                         let translations = parseTranslations(dict: dict)
                         guard !translations.isEmpty else { throw AppError.parseFailed }


### PR DESCRIPTION
The current app can't parse the Chinese translation database because the translation repo updated the version number. After testing, it shows that changing the version number from 5 to 6 can solve this problem.