### PR TITLE
move indirect from case to enum, make the App crash gone

### DIFF
--- a/EhPanda/View/Detail/DataFlow/CommentsStore.swift
+++ b/EhPanda/View/Detail/DataFlow/CommentsStore.swift
@@ -41,7 +41,7 @@ struct CommentsState: Equatable {
     var detailReducer: Reducer<DetailState, DetailAction, DetailEnvironment>?
 }
 
-enum CommentsAction: BindableAction {
+indirect enum CommentsAction: BindableAction {
     case binding(BindingAction<CommentsState>)
     case setNavigation(CommentsState.Route?)
     case setDetailState(DetailState)
@@ -67,7 +67,7 @@ enum CommentsAction: BindableAction {
     case fetchGallery(URL, Bool)
     case fetchGalleryDone(URL, Result<Gallery, AppError>)
 
-    indirect case detail(id: String, action: DetailAction)
+    case detail(id: String, action: DetailAction)
 }
 
 struct CommentsEnvironment {

--- a/EhPanda/View/Detail/DataFlow/DetailStore.swift
+++ b/EhPanda/View/Detail/DataFlow/DetailStore.swift
@@ -92,7 +92,7 @@ struct DetailState: Equatable, Identifiable {
     }
 }
 
-enum DetailAction: BindableAction {
+indirect enum DetailAction: BindableAction {
     case binding(BindingAction<DetailState>)
     case setNavigation(DetailState.Route?)
     case setSearchRequestState(SearchRequestState)
@@ -137,7 +137,7 @@ enum DetailAction: BindableAction {
     case previews(PreviewsAction)
     case comments(CommentsAction)
     case galleryInfos(GalleryInfosAction)
-    indirect case searchRequest(id: String, action: SearchRequestAction)
+    case searchRequest(id: String, action: SearchRequestAction)
 }
 
 struct DetailEnvironment {


### PR DESCRIPTION
No idea why, but this changes make crash gone.