### PR TITLE
fix: 修复登录页面用户名输入框阻止切换中文键盘的问题

### DIFF
--- a/EhPanda/View/Setting/Support/LoginView.swift
+++ b/EhPanda/View/Setting/Support/LoginView.swift
@@ -114,8 +114,9 @@ private struct LoginTextField: View {
             }
             .focused(focusedField.projectedValue, equals: isPassword ? .password : .username)
             .textContentType(isPassword ? .password : .username).submitLabel(isPassword ? .done : .next)
-            .textInputAutocapitalization(.none).disableAutocorrection(true).keyboardType(isPassword ? .asciiCapable : .default)
-            .padding(10).background(backgroundColor.opacity(0.75).cornerRadius(8))
+            .textInputAutocapitalization(.none).disableAutocorrection(true)
+            .keyboardType(isPassword ? .asciiCapable : .default).padding(10)
+            .background(backgroundColor.opacity(0.75).cornerRadius(8))
         }
     }
 }

--- a/EhPanda/View/Setting/Support/LoginView.swift
+++ b/EhPanda/View/Setting/Support/LoginView.swift
@@ -114,7 +114,7 @@ private struct LoginTextField: View {
             }
             .focused(focusedField.projectedValue, equals: isPassword ? .password : .username)
             .textContentType(isPassword ? .password : .username).submitLabel(isPassword ? .done : .next)
-            .textInputAutocapitalization(.none).disableAutocorrection(true).keyboardType(.asciiCapable)
+            .textInputAutocapitalization(.none).disableAutocorrection(true).keyboardType(isPassword ? .asciiCapable : .default)
             .padding(10).background(backgroundColor.opacity(0.75).cornerRadius(8))
         }
     }


### PR DESCRIPTION
本人ex账户用户名中含有中文字符
直接使用登录页面的输入框无法切换至中文键盘 只能通过粘贴或者网页登录授权

代码已经过测试
测试机型 iPhone XR 操作系统 iOS15.3